### PR TITLE
Avoid n+1 in dashboard, add balance total for money accounts, fix progress bar component

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -9,7 +9,7 @@ class DashboardController < ApplicationController
 
     if params[:tab_content] == "tab_user" && params[:user_id].present?
       @user = User.find(params[:user_id])
-      @user_expenses = @user.expenses.includes(:budget)
+      @user_expenses = @user.expenses.includes(:budget, :money_account, :expense_splits)
     end
   end
 

--- a/app/controllers/money_accounts_controller.rb
+++ b/app/controllers/money_accounts_controller.rb
@@ -4,6 +4,7 @@ class MoneyAccountsController < ApplicationController
   def index
     @money_accounts = MoneyAccount.all
     @transactions = transactions
+    @global_account = MoneyAccountsBalance.new(current_account)
   end
 
   def new
@@ -47,11 +48,14 @@ class MoneyAccountsController < ApplicationController
   end
 
   def find_money_account
-    @money_account = MoneyAccount.find(params[:id])
+    @money_account = current_account.money_accounts.find(params[:id])
   end
 
   def transactions
-    current_account.transactions.includes(:user).
-      order(transaction_date: :desc, created_at: :desc)
+    current_account
+      .transactions
+      .no_fixed
+      .includes(:user)
+      .order(transaction_date: :desc, created_at: :desc)
   end
 end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -7,4 +7,8 @@ class Account < ApplicationRecord
   has_many :transactions, dependent: :destroy
   has_many :incomings, class_name: "Incoming"
   has_many :expenses, class_name: "Expense"
+
+  def money_accounts_balance
+    money_accounts.sum(&:balance)
+  end
 end

--- a/app/views/components/progress_component.rb
+++ b/app/views/components/progress_component.rb
@@ -9,22 +9,15 @@ class ProgressComponent < Phlex::HTML
   def view_template
     div(
       class: [
-        "relative h-4 w-full overflow-hidden rounded-full bg-gray-100",
+        "relative h-4 w-full overflow-hidden rounded-full bg-gray-200",
         @class
       ].compact.join(" "),
       **@attrs
     ) do
       div(
         class: "h-full bg-blue-600 transition-all duration-300 ease-in-out",
-        style: "width: #{progress_percentage}%"
+        style: "width: #{@value.to_i}px"
       )
     end
-  end
-
-  private
-
-  def progress_percentage
-    return 0 if @max.zero?
-    [(@value.to_f / @max * 100), 100].min
   end
 end

--- a/app/views/money_accounts/_money_account.html.erb
+++ b/app/views/money_accounts/_money_account.html.erb
@@ -1,6 +1,6 @@
 <%= turbo_frame_tag dom_id(account) do %>
-  <%= render CardComponent.new do %>
-    <%= render CardComponent::Header.new do %>
+  <%= render CardComponent.new(class: 'border border-gray-300') do %>
+    <%= render CardComponent::Header.new(class: 'pb-2') do %>
       <div class="flex items-center justify-between">
         <%= render CardComponent::Title.new(class: "text-sm font-medium") { account.name } %>
 

--- a/app/views/money_accounts/_total_balance.html.erb
+++ b/app/views/money_accounts/_total_balance.html.erb
@@ -1,0 +1,13 @@
+<%= turbo_frame_tag 'total_balance' do %>
+  <%= render CardComponent.new(class: 'bg-blue-500 text-white pb-5') do %>
+    <%= render CardComponent::Header.new(class: 'pb-2') do %>
+      <div class="flex items-center justify-between">
+        <%= render CardComponent::Title.new(class: "text-sm font-medium") { account.name } %>
+      </div>
+    <% end %>
+
+    <%= render CardComponent::Content.new(class: 'flex align-items-end justify-between') do %>
+      <div class="text-2xl font-bold"><%= to_money_format account.balance %></div>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/money_accounts/index.html.erb
+++ b/app/views/money_accounts/index.html.erb
@@ -10,6 +10,8 @@
   <%= render partial: 'layouts/header' %>
 
   <div id="money_accounts" class="accounts-card--container">
+    <%= render partial: 'money_accounts/total_balance', locals: { account: @global_account } %>
+
     <% @money_accounts.each do |account| %>
       <%= render partial: 'money_accounts/money_account', locals: { account: account } %>
     <% end %>


### PR DESCRIPTION
This pull request introduces several changes across controllers, models, and views to enhance functionality and improve the user interface for managing money accounts and transactions. The most significant updates include adding a global account balance feature, refining transaction filtering, and updating the visual design of components.

### Enhancements to Money Account Management:
* [`app/controllers/money_accounts_controller.rb`](diffhunk://#diff-650009ac1260ad66011ee1b175685f8a1ce793b8a4e3683fc5592296969ebc4aR7): Introduced a `@global_account` instance variable using `MoneyAccountsBalance` to calculate the overall balance of money accounts. Updated `find_money_account` to scope searches to the current account and refined transaction filtering by excluding fixed transactions (`no_fixed`). [[1]](diffhunk://#diff-650009ac1260ad66011ee1b175685f8a1ce793b8a4e3683fc5592296969ebc4aR7) [[2]](diffhunk://#diff-650009ac1260ad66011ee1b175685f8a1ce793b8a4e3683fc5592296969ebc4aL50-R59)
* [`app/models/account.rb`](diffhunk://#diff-b3ff5e3df6b875e9ecfde657ae21de84f4f43c942d3232761ed550cf0eecbce0R10-R13): Added a `money_accounts_balance` method to calculate the total balance of all associated money accounts.

### UI Improvements:
* [`app/views/money_accounts/index.html.erb`](diffhunk://#diff-463ebfa5ee1f5acc53397f824ffd40f1b16f8eff14b9612351d0964d1d37b88eR13-R14): Added a new partial to display the total balance of money accounts (`total_balance`) using the `@global_account` variable.
* [`app/views/money_accounts/_money_account.html.erb`](diffhunk://#diff-eabc0fd2735e152b8e6244f02044c2d7260576e35b07c8423f5e121f3a78fa04L2-R3): Updated the `CardComponent` for individual money accounts with additional styling (`border border-gray-300`) and refined header spacing (`pb-2`).
* [`app/views/money_accounts/_total_balance.html.erb`](diffhunk://#diff-e25b9a28569e7421d87e6fff243ab6f03d8a9e3ffc27adee38e63adf833101b2R1-R13): Created a new partial to display the total balance with a visually distinct design (`bg-blue-500 text-white pb-5`).

### Adjustments to Progress Component:
* [`app/views/components/progress_component.rb`](diffhunk://#diff-cff0ec5152a954ff71b1541ee11fd52d20c6231f0e894a768abc8d4d09bccfcbL12-L29): Changed the background color of the progress bar (`bg-gray-200`) and updated the width calculation to use pixel values (`@value.to_i`) instead of percentage-based logic. Removed the `progress_percentage` private method.