### PR TITLE
Add color and icon to budget

### DIFF
--- a/app/controllers/budgets_controller.rb
+++ b/app/controllers/budgets_controller.rb
@@ -41,6 +41,6 @@ class BudgetsController < ApplicationController
   end
 
   def budget_params
-    params.require(:budget).permit(:name, :amount, :budget_type)
+    params.require(:budget).permit(:name, :amount, :color, :icon, :budget_type)
   end
 end

--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -12,6 +12,36 @@ class Budget < ApplicationRecord
   validates :amount, presence: true, numericality: { greater_than: 0 }
   validates :user_id, presence: true, if: :personal?
 
+  ICONS = %w[
+    alarm-clock
+    armchair
+    award
+    badge-check
+    banknote
+    biceps-flexed
+    bookmark
+    boxes
+    bubbles
+    cake
+    car
+    coffee
+    concierge-bell
+    cookie
+    dog
+    flag
+    gamepad-2
+    github
+    hand-coins
+    heart
+    house
+    laugh
+    lock-keyhole
+    medal
+    music
+  ].freeze
+
+  validates :icon, inclusion: { in: ICONS }, allow_blank: true
+
   def is_over_budget?
     # spent_amount > amount
   end
@@ -21,8 +51,8 @@ class Budget < ApplicationRecord
   end
 
   def percentage
-    return 0 if amount.zero?
+    return 0 if amount.zero? || total_expenses.zero?
 
-    (total_expenses.to_f / amount.to_f * 100).round(2)
+    ((amount.to_f * 100 / total_expenses.to_f) * 100).round(2)
   end
 end

--- a/app/views/budgets/_budget.html.erb
+++ b/app/views/budgets/_budget.html.erb
@@ -1,11 +1,22 @@
 <%= turbo_frame_tag dom_id(budget) do %>
   <%= render CardComponent.new do %>
-    <%= render CardComponent::Header.new do %>
+    <%= render CardComponent::Header.new(class: 'flex justify-between pb-0', style: 'flex-direction: row;') do %>
+      <div>
+        <%= lucide_icon(budget.icon, class: "text-lg") %>
+
+        <%= render BadgeComponent.new(variant: :dynamic_color, class: "md:hidden", style: "background-color: #{budget.color}; color: white;") do %>
+          <%= budget.name %>
+        <% end %>
+      </div>
+
       <div class="flex items-center justify-between">
-        <%= render CardComponent::Title.new(class: "text-sm font-medium") { budget.name } %>
+
+        <%= render BadgeComponent.new(variant: :dynamic_color, class: "hidden md:block", style: "background-color: #{budget.color}; color: white;") do %>
+          <%= budget.name %>
+        <% end %>
 
         <div class="hidden relative md:inline-block text-left">
-          <a data-action="click -> dropdown#toggle" data-controller="dropdown" class="p0 align-items-center cursor-pointer inline-flex w-full justify-center gap-x-1.5 rounded-md px-3 py-2 text-sm font-semibold text-gray-900" aria-expanded="true" aria-haspopup="true">
+          <a data-action="click -> dropdown#toggle" data-controller="dropdown" class="p0 align-items-center cursor-pointer inline-flex w-full justify-center gap-x-1.5 rounded-md px-3 py-2 text-sm font-semibold text-gray-900 align-middle" aria-expanded="true" aria-haspopup="true">
             <%= lucide_icon 'more-vertical', class: 'w-6 h-6 text-gray-600' %>
           </a>
 
@@ -34,7 +45,7 @@
       <p class="text-xs text-gray-500">de <%= to_money_format budget.total_expenses %> presupuestados</p>
       <p class="text-xs text-gray-500">Monto límite: <%= budget.amount.format %></p>
 
-      <%= render ProgressComponent.new(value: budget.percentage, class: "mt-2") %>
+      <%= render ProgressComponent.new(value: budget.percentage, class: "mt-2", color: budget.color) %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/budgets/_form.html.erb
+++ b/app/views/budgets/_form.html.erb
@@ -1,5 +1,11 @@
 <%= f.input :name %>
-<%= f.input :amount %>
+
+<div class="flex gap-2">
+  <%= f.input :amount %>
+  <%= f.input :color, as: :color, input_html: { style: 'width: 4rem;' } %>
+</div>
+
+<%= f.input :icon, as: :select, collection: Budget::ICONS, include_blank: false, input_html: { class: 'w-full', data: { controller: 'slimselect' } } %>
 
 <div class="mb-6 gap-4 flex justify-center border border-gray-200 p-5">
   <%= f.collection_radio_buttons :budget_type, [['personal', 'Personal'], ['shared', 'Compartido']], :first, :last %>

--- a/app/views/components/badge_component.rb
+++ b/app/views/components/badge_component.rb
@@ -1,8 +1,9 @@
 class BadgeComponent < Phlex::HTML
   VARIANTS = {
-    default: "border-transparent bg-blue-900 text-gray-100",
-    secondary: "border-transparent bg-gray-900 text-gray-100",
-    outline: "text-gray-950 border-gray-200"
+    default: "border-transparent bg-blue-900 text-gray-100 md:inline-flex",
+    secondary: "border-transparent bg-gray-900 text-gray-100 md:inline-flex",
+    outline: "text-gray-950 border-gray-200 md:inline-flex",
+    dynamic_color: ""
   }.freeze
 
   def initialize(variant: :default, class: nil, **attrs)
@@ -14,7 +15,7 @@ class BadgeComponent < Phlex::HTML
   def view_template(&block)
     span(
       class: [
-        "md:inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-gray-950 focus:ring-offset-2",
+        "items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-gray-950 focus:ring-offset-2",
         VARIANTS[@variant],
         @class
       ].compact.join(" "),

--- a/app/views/components/progress_component.rb
+++ b/app/views/components/progress_component.rb
@@ -1,23 +1,28 @@
 class ProgressComponent < Phlex::HTML
-  def initialize(value:, max: 100, class: nil, **attrs)
+  def initialize(value:, max: 100, class: nil, color: nil, **attrs)
     @value = value
     @max = max
     @class = binding.local_variable_get(:class)
     @attrs = attrs
+    @color = value > 100 ? "red" : color
   end
 
   def view_template
     div(
       class: [
-        "relative h-4 w-full overflow-hidden rounded-full bg-gray-200",
+        "relative h-4 w-full overflow-hidden rounded-full #{@color ? '' : 'bg-gray-200'}",
         @class
       ].compact.join(" "),
       **@attrs
     ) do
       div(
-        class: "h-full bg-blue-600 transition-all duration-300 ease-in-out",
-        style: "width: #{@value.to_i}px"
+        class: "h-full transition-all duration-300 ease-in-out",
+        style: "width: #{calc_pixels}px; #{ @color ? "background-color: #{@color};" : '' }"
       )
     end
+  end
+
+  def calc_pixels
+    [@value.to_i, 100].min
   end
 end

--- a/db/migrate/20250706141351_add_color_to_budget.rb
+++ b/db/migrate/20250706141351_add_color_to_budget.rb
@@ -1,0 +1,6 @@
+class AddColorToBudget < ActiveRecord::Migration[8.0]
+  def change
+    add_column :budgets, :color, :string, default: '#000000', null: false
+    add_column :budgets, :icon, :string, default: 'flame', null: false # to use with lucide icons
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_04_220433) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_06_141351) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -29,6 +29,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_04_220433) do
     t.integer "budget_type", default: 0, null: false
     t.bigint "account_id", null: false
     t.bigint "user_id"
+    t.string "color", default: "#000000", null: false
+    t.string "icon", default: "flame", null: false
     t.index ["account_id"], name: "index_budgets_on_account_id"
     t.index ["user_id"], name: "index_budgets_on_user_id"
   end


### PR DESCRIPTION
This pull request enhances the budget management system by introducing support for customizable colors and icons for budgets. It includes changes to the backend, database schema, and frontend components to enable these new features.

### Backend Changes

* **Model Updates**: Added an `ICONS` constant to `Budget` for supported icons and validated the `icon` attribute to ensure it matches one of the predefined options.  
* **Budget Calculations**: Updated the `percentage` method in `Budget` to handle cases where `total_expenses` is zero and corrected the calculation formula for percentage.

### Frontend Changes

* **Budget Form**: Updated the budget creation/edit form to include fields for selecting a color and an icon, with appropriate styling and dropdown functionality.  
* **Budget Display**: Modified the budget card view to show the selected icon and use the dynamic color for badges and progress bars. [[1]](diffhunk://#diff-e578d785ae6df66641a22d0acacd96850ba760b2f094d35753db4e2057208db5L3-R19) [[2]](diffhunk://#diff-e578d785ae6df66641a22d0acacd96850ba760b2f094d35753db4e2057208db5L37-R48)  
* **Component Updates**: Enhanced the `BadgeComponent` to support dynamic colors and updated the `ProgressComponent` to use the budget color or red for values exceeding 100%. [[1]](diffhunk://#diff-dcbbba5228329bd3450abf527058456442981fd3f1ce101df1b09bcf4098d0e1L3-R6) [[2]](diffhunk://#diff-dcbbba5228329bd3450abf527058456442981fd3f1ce101df1b09bcf4098d0e1L17-R18) [[3]](diffhunk://#diff-cff0ec5152a954ff71b1541ee11fd52d20c6231f0e894a768abc8d4d09bccfcbL2-R27)

### Database Changes

* **Migration**: Added `color` and `icon` columns to the `budgets` table with default values and constraints.  
* **Schema Update**: Reflected the new columns (`color` and `icon`) in the database schema. [[1]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3L13-R13) [[2]](diffhunk://#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3R32-R33)